### PR TITLE
Allow areas to be optionally open to all other users

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -24,7 +24,9 @@ function areas:canInteract(pos, name)
 		if area.owner == name then
 			return true
 		else
-			owned = true
+			if not area.open then
+				owned = true
+			end
 		end
 	end
 	return not owned

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -305,3 +305,31 @@ minetest.register_chatcommand("change_owner", {
 				name..'" has given you control over an area.')
 end})
 
+minetest.register_chatcommand("area_open", {
+	params = "<id> <yes/no>",
+	description = "Set area open (anyone can interact) or not",
+	privs = {},
+	func = function(name, param)
+		local found, _, id, yesno =
+				param:find('^(%d+) (%l+)$')
+
+		if not found  or (yesno ~= "yes" and yesno ~= "no") then
+			minetest.chat_send_player(name,
+					"Invalid usage,"
+					.." see /help area_open")
+			return
+		end
+		
+		id = tonumber(id)
+		if not areas:isAreaOwner(id, name) then
+			minetest.chat_send_player(name,
+					"Area "..id.." does not exist"
+					.." or is not owned by you.")
+			return
+		end
+		areas.areas[id].open = yesno == "yes"
+		areas:save()
+		minetest.chat_send_player(name, 'Area updated.')
+end})
+
+

--- a/hud.lua
+++ b/hud.lua
@@ -15,7 +15,11 @@ minetest.register_globalstep(function(dtime)
 			else
 				first = false
 			end
-			areaString = areaString..id.." ("..area.owner..")"
+			local ownertxt = area.owner
+			if area.open then
+				ownertxt = ownertxt.."/open"
+			end
+			areaString = areaString..id.." ("..ownertxt..")"
 		end
 		if not areas.hud[name] then
 			areas.hud[name] = {}


### PR DESCRIPTION
In other words, you can retain ownership of an area but disable and
re-enable the protection aspect at will, via the area_open chat command.

By default, nothing is any different following this commit - all
existing areas are protected, as are new ones. But you can do (for
example) "area_open 1 yes" and if you're the owner of that area, it's
now possible for other users to interact there. "area_open 1 no" to
switch the protection back on.

Where there are sub-areas, the main owner and ALL sub-area owners at a
particulare location must have set the areas to open to disable
protection.
