### PR TITLE
Don't use auth_table, use get_auth_handler().get_auth instead

### DIFF
--- a/internal.lua
+++ b/internal.lua
@@ -1,6 +1,6 @@
 
 function areas:player_exists(name)
-	return minetest.auth_table[name] ~= nil
+	return minetest.get_auth_handler().get_auth(name) ~= nil
 end
 
 -- Save the areas table to a file


### PR DESCRIPTION
No guarantee is made auth_table contains auth entries or even exists.
Using this table directly is incompatible with auth handlers that don't
cache auth entries (e.g. when they are stored in an SQL database
supposed to be concurrently accessed and modified).
