### PR TITLE
Replace deprecated methods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -32,7 +32,7 @@ if not minetest.registered_privileges[areas.config.self_protection_privilege] th
 	})
 end
 
-if minetest.setting_getbool("log_mod") then
+if minetest.settings:get_bool("log_mod") then
 	local diffTime = os.clock() - areas.startTime
 	minetest.log("action", "areas loaded in "..diffTime.."s.")
 end

--- a/settings.lua
+++ b/settings.lua
@@ -6,13 +6,13 @@ local function setting(tp, name, default)
 	local full_name = "areas."..name
 	local value
 	if tp == "boolean" then
-		value = minetest.setting_getbool(full_name)
+		value = minetest.settings:get_bool(full_name)
 	elseif tp == "string" then
-		value = minetest.setting_get(full_name)
+		value = minetest.settings:get(full_name)
 	elseif tp == "position" then
 		value = minetest.setting_get_pos(full_name)
 	elseif tp == "number" then
-		value = tonumber(minetest.setting_get(full_name))
+		value = tonumber(minetest.settings:get(full_name))
 	else
 		error("Invalid setting type!")
 	end


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267