### PR TITLE
fix a crash happening if pos is too big

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -18,6 +18,11 @@ end
 function areas:getAreasAtPos(pos)
 	local res = {}
 
+	if math.abs(pos.x) > 2147483 or math.abs(pos.y) > 2147483 or
+			math.abs(pos.z) > 2147483 then
+		return res
+	end
+
 	if self.store then
 		local a = self.store:get_areas_for_pos(pos, false, true)
 		for store_id, store_area in pairs(a) do

--- a/api.lua
+++ b/api.lua
@@ -18,10 +18,9 @@ end
 function areas:getAreasAtPos(pos)
 	local res = {}
 
-	if math.abs(pos.x) > 2147483 or math.abs(pos.y) > 2147483 or
-			math.abs(pos.z) > 2147483 then
-		return res
-	end
+	pos = vector.apply(pos, function(p)
+		return math.max(math.min(p, 2147483), -2147483)
+	end)
 
 	if self.store then
 		local a = self.store:get_areas_for_pos(pos, false, true)

--- a/api.lua
+++ b/api.lua
@@ -18,10 +18,6 @@ end
 function areas:getAreasAtPos(pos)
 	local res = {}
 
-	pos = vector.apply(pos, function(p)
-		return math.max(math.min(p, 2147483), -2147483)
-	end)
-
 	if self.store then
 		local a = self.store:get_areas_for_pos(pos, false, true)
 		for store_id, store_area in pairs(a) do

--- a/hud.lua
+++ b/hud.lua
@@ -6,6 +6,9 @@ minetest.register_globalstep(function(dtime)
 	for _, player in pairs(minetest.get_connected_players()) do
 		local name = player:get_player_name()
 		local pos = vector.round(player:getpos())
+		pos = vector.apply(pos, function(p)
+			return math.max(math.min(p, 2147483), -2147483)
+		end)
 		local areaStrings = {}
 
 		for id, area in pairs(areas:getAreasAtPos(pos)) do


### PR DESCRIPTION
[A german server](https://forum.minetest.net/viewtopic.php?f=21&t=17959&start=50#p284157) had/has crashes with enabled `disable_anticheat`. This was the debug output:
```
{
y = 12,
x = -2147484,
z = -706
}

2017-07-18 13:56:00: ERROR[Main]: ServerError: AsyncErr: environment_Step: Runtime error from mod 'areas' in callback environment_Step(): Invalid float vector dimension range 'x' (expected -2.14748e+06 < x < 2.14748e+06 got -2.14748e+06).
2017-07-18 13:56:00: ERROR[Main]: stack traceback:
2017-07-18 13:56:00: ERROR[Main]:    [C]: in function 'get_areas_for_pos'
2017-07-18 13:56:00: ERROR[Main]:    ...bolus/minetest-server/minetest/bin/../mods/areas/api.lua:23: in function 'getAreasAtPos'
2017-07-18 13:56:00: ERROR[Main]:    ...bolus/minetest-server/minetest/bin/../mods/areas/hud.lua:11: in function <...bolus/minetest-server/minetest/bin/../mods/areas/hud.lua:5>
2017-07-18 13:56:00: ERROR[Main]:    ...inetest-server/minetest/bin/../builtin/game/register.lua:412: in function <...inetest-server/minetest/bin/../builtin/game/register.lua:392>
2017-07-18 13:56:00: ERROR[Main]: stack traceback:
```