### PR TITLE
Add a refresh delay on globalstep

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -45,4 +45,4 @@ file:close()
 setting("filename", "string", world_path.."/areas.dat")
 
 -- configure the refresh delay for the name displays in the HUD
-setting("number", "tick", 0.5)
+setting("tick", "float", 0.5)

--- a/settings.lua
+++ b/settings.lua
@@ -44,3 +44,5 @@ file:close()
 
 setting("filename", "string", world_path.."/areas.dat")
 
+-- configure the refresh delay for the name displays in the HUD
+setting("number", "tick", 0.5)


### PR DESCRIPTION
The unchecked globalstep causes re-calculation of area checks for all players on each tick. On larger servers, this quickly becomes a potential source of CPU pressure.

This change adds a configurable refresh delay to allow server admins to alleviate the pressure, defaulting to a slower refresh rate.