### PR TITLE
Add support for playerfactions mod

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -94,6 +94,11 @@ function areas:canInteract(pos, name)
 	for _, area in pairs(self:getAreasAtPos(pos)) do
 		if area.owner == name or area.open then
 			return true
+		elseif factions then
+			local faction_name = factions.get_player_faction(area.owner)
+			if faction_name ~= nil and faction_name == factions.get_player_faction(name) then
+				return true
+			end
 		else
 			owned = true
 		end

--- a/api.lua
+++ b/api.lua
@@ -94,14 +94,13 @@ function areas:canInteract(pos, name)
 	for _, area in pairs(self:getAreasAtPos(pos)) do
 		if area.owner == name or area.open then
 			return true
-		elseif factions then
+		elseif factions and area.faction_open then
 			local faction_name = factions.get_player_faction(area.owner)
 			if faction_name ~= nil and faction_name == factions.get_player_faction(name) then
 				return true
 			end
-		else
-			owned = true
 		end
+		owned = true
 	end
 	return not owned
 end

--- a/api.lua
+++ b/api.lua
@@ -94,7 +94,7 @@ function areas:canInteract(pos, name)
 	for _, area in pairs(self:getAreasAtPos(pos)) do
 		if area.owner == name or area.open then
 			return true
-		elseif factions_avail and area.faction_open then
+		elseif areas.factions_available and area.faction_open then
 			local faction_name = factions.get_player_faction(area.owner)
 			if faction_name ~= nil and faction_name == factions.get_player_faction(name) then
 				return true

--- a/api.lua
+++ b/api.lua
@@ -94,7 +94,7 @@ function areas:canInteract(pos, name)
 	for _, area in pairs(self:getAreasAtPos(pos)) do
 		if area.owner == name or area.open then
 			return true
-		elseif factions and area.faction_open then
+		elseif factions_avail and area.faction_open then
 			local faction_name = factions.get_player_faction(area.owner)
 			if faction_name ~= nil and faction_name == factions.get_player_faction(name) then
 				return true

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -289,7 +289,7 @@ minetest.register_chatcommand("area_open", {
 if areas.factions_available then
 	minetest.register_chatcommand("area_faction_open", {
 		params = "<ID>",
-		description = "Toggle an area open (anyone can interact) or closed to your faction",
+		description = "Toggle an area open/closed for members in your faction."
 		func = function(name, param)
 			local id = tonumber(param)
 			if not id then

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -286,6 +286,30 @@ minetest.register_chatcommand("area_open", {
 })
 
 
+if factions then
+	minetest.register_chatcommand("area_faction_open", {
+		params = "<ID>",
+		description = "Toggle an area open (anyone can interact) or closed to your faction",
+		func = function(name, param)
+			local id = tonumber(param)
+			if not id then
+				return false, "Invalid usage, see /help area_faction_open."
+			end
+			
+			if not areas:isAreaOwner(id, name) then
+				return false, "Area "..id.." does not exist"
+						.." or is not owned by you."
+			end
+			local open = not areas.areas[id].faction_open
+			-- Save false as nil to avoid inflating the DB.
+			areas.areas[id].faction_open = open or nil
+			areas:save()
+			return true, ("Area %s for faction members."):format(open and "opened" or "closed")
+		end
+	})
+end
+
+
 minetest.register_chatcommand("move_area", {
 	params = "<ID>",
 	description = "Move (or resize) an area to the current positions.",

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -286,7 +286,7 @@ minetest.register_chatcommand("area_open", {
 })
 
 
-if factions then
+if factions_avail then
 	minetest.register_chatcommand("area_faction_open", {
 		params = "<ID>",
 		description = "Toggle an area open (anyone can interact) or closed to your faction",

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -289,7 +289,7 @@ minetest.register_chatcommand("area_open", {
 if areas.factions_available then
 	minetest.register_chatcommand("area_faction_open", {
 		params = "<ID>",
-		description = "Toggle an area open/closed for members in your faction."
+		description = "Toggle an area open/closed for members in your faction.",
 		func = function(name, param)
 			local id = tonumber(param)
 			if not id then

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -286,7 +286,7 @@ minetest.register_chatcommand("area_open", {
 })
 
 
-if factions_avail then
+if areas.factions_available then
 	minetest.register_chatcommand("area_faction_open", {
 		params = "<ID>",
 		description = "Toggle an area open (anyone can interact) or closed to your faction",

--- a/hud.lua
+++ b/hud.lua
@@ -21,13 +21,13 @@ minetest.register_globalstep(function(dtime)
 		local areaStrings = {}
 
 		for id, area in pairs(areas:getAreasAtPos(pos)) do
-			if area.faction_open and (areas.faction_available == false or factions.get_player_faction(area.owner) == nil) then
-				area.faction_open = false
-			end
+			local faction_info = area.faction_open and areas.factions_available and
+					factions.get_player_faction(area.owner)
+			area.faction_open = faction_info
 			table.insert(areaStrings, ("%s [%u] (%s%s%s)")
 					:format(area.name, id, area.owner,
 					area.open and ":open" or "",
-					area.faction_open and ":"..factions.get_player_faction(area.owner) or ""))
+					faction_info and ":"..faction_info or ""))
 		end
 
 		for i, area in pairs(areas:getExternalHudEntries(pos)) do

--- a/hud.lua
+++ b/hud.lua
@@ -21,10 +21,13 @@ minetest.register_globalstep(function(dtime)
 		local areaStrings = {}
 
 		for id, area in pairs(areas:getAreasAtPos(pos)) do
+			if area.faction_open and (areas.faction_available == false or factions.get_player_faction(area.owner) == nil) then
+				area.faction_open = false
+			end
 			table.insert(areaStrings, ("%s [%u] (%s%s%s)")
 					:format(area.name, id, area.owner,
 					area.open and ":open" or "",
-					area.faction_open and ":faction" or ""))
+					area.faction_open and ":"..factions.get_player_faction(area.owner) or ""))
 		end
 
 		for i, area in pairs(areas:getExternalHudEntries(pos)) do

--- a/hud.lua
+++ b/hud.lua
@@ -21,9 +21,10 @@ minetest.register_globalstep(function(dtime)
 		local areaStrings = {}
 
 		for id, area in pairs(areas:getAreasAtPos(pos)) do
-			table.insert(areaStrings, ("%s [%u] (%s%s)")
+			table.insert(areaStrings, ("%s [%u] (%s%s%s)")
 					:format(area.name, id, area.owner,
-					area.open and ":open" or ""))
+					area.open and ":open" or "",
+					area.faction_open and ":faction" or ""))
 		end
 
 		for i, area in pairs(areas:getExternalHudEntries(pos)) do

--- a/init.lua
+++ b/init.lua
@@ -2,9 +2,9 @@
 -- Based on node_ownership
 -- License: LGPLv2+
 
-factions_avail = minetest.global_exists("factions")
-
 areas = {}
+
+areas.factions_available = minetest.global_exists("factions")
 
 areas.adminPrivs = {areas=true}
 areas.startTime = os.clock()

--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,8 @@
 -- Based on node_ownership
 -- License: LGPLv2+
 
+factions_avail = minetest.global_exists("factions")
+
 areas = {}
 
 areas.adminPrivs = {areas=true}

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,2 @@
 name = areas
+optional_depends = factions

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = areas
-optional_depends = factions
+optional_depends = playerfactions


### PR DESCRIPTION
Hello, I'm still pretty new to Minetest mod development in general so please correct me if I'm going about this wrong.

Frustrated by the lack of a way to manage allowing large groups of people to access certain areas, I've developed a `factions` mod which allows players to create and invite each other to factions. There's currently some room for improvement within the `factions` mod itself, but it is functional in its current state.

I've written some patches for the `areas` mod to allow players to control access to their areas using factions. It's an optional dependency of course, so existing users are completely unaffected. Specifically, it adds one command, `/area_faction_open <ID>`, which functions exactly the same as `/area_open <ID>` except that it opens/closes the area to faction members only.

I've done some testing on my own, and it seems to work fine. If somebody else would like to test it I'll be happy to help in any way I can. The actual factions mod can be found [here](https://git.leagueh.xyz/katp32/playerfactions).

Thanks for your time!