### PR TITLE
/areas_cleanup for removing ownerless areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,3 @@ Copyright (C) 2013 ShadowNinja
 
 Licensed under the GNU LGPL version 2.1 or later.
 See LICENSE.txt and http://www.gnu.org/licenses/lgpl-2.1.txt
-

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Commands
 
   * `/area_pos2 [X,Y,Z|X Y Z]` -- Sets area position two to your position or
 	the one supplied.
+	
+  * `/areas_cleanup` -- Removes all ownerless areas.
+	Useful for cleaning after user deletion, for example using /remove_player.
 
 License
 -------

--- a/api.lua
+++ b/api.lua
@@ -1,6 +1,5 @@
 local hudHandlers = {}
 
-
 areas.registered_on_adds = {}
 areas.registered_on_removes = {}
 areas.registered_on_moves = {}
@@ -17,12 +16,10 @@ function areas:registerOnMove(func)
 	table.insert(areas.registered_on_moves, func)
 end
 
-
 --- Adds a function as a HUD handler, it will be able to add items to the Areas HUD element.
 function areas:registerHudHandler(handler)
 	table.insert(hudHandlers, handler)
 end
-
 
 function areas:getExternalHudEntries(pos)
 	local areas = {}
@@ -118,7 +115,7 @@ end
 -- Note that this fails and returns false when the specified area is fully
 -- owned by the player, but with multiple protection zones, none of which
 -- cover the entire checked area.
--- @param name (optional) Player name.  If not specified checks for any intersecting areas.
+-- @param name (optional) Player name. If not specified checks for any intersecting areas.
 -- @param allow_open Whether open areas should be counted as if they didn't exist.
 -- @return Boolean indicating whether the player can interact in that area.
 -- @return Un-owned intersecting area ID, if found.

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -75,8 +75,7 @@ minetest.register_chatcommand("add_owner", {
 		.." positions that have already been protected,"
 		.." Use set_owner if you don't want the parent to be set."),
 	func = function(name, param)
-		local pid, ownerName, areaName
-				= param:match('^(%d+) ([^ ]+) (.+)$')
+		local pid, ownerName, areaName = param:match('^(%d+) ([^ ]+) (.+)$')
 
 		if not pid then
 			minetest.chat_send_player(name, S("Invalid usage, see /help @1.", "add_owner"))
@@ -294,7 +293,7 @@ if areas.factions_available then
 			if not id then
 				return false, S("Invalid usage, see /help @1.", "area_faction_open")
 			end
-			
+
 			if not areas:isAreaOwner(id, name) then
 				return false, S("Area @1 does not exist"
 						.." or is not owned by you.", id)
@@ -386,7 +385,7 @@ minetest.register_chatcommand("area_info", {
 				area_num = area_num + 1
 			end
 		end
-		table.insert(lines, S("You have @1 areas.", area_num)) 
+		table.insert(lines, S("You have @1 areas.", area_num))
 
 		-- Area limit
 		local area_limit_line = privs.areas and
@@ -418,4 +417,3 @@ minetest.register_chatcommand("area_info", {
 		return true, table.concat(lines, "\n")
 	end,
 })
-

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -417,3 +417,28 @@ minetest.register_chatcommand("area_info", {
 		return true, table.concat(lines, "\n")
 	end,
 })
+
+
+minetest.register_chatcommand("areas_cleanup", {
+	description = S("Removes all ownerless areas"),
+	privs = areas.adminPrivs,
+	func = function()
+		local total, count = 0, 0
+
+		local aareas = areas.areas
+		for id, _ in pairs(aareas) do
+			local owner = aareas[id].owner
+
+			if not areas:player_exists(owner) then
+				areas:remove(id)
+				count = count + 1
+			end
+
+			total = total + 1
+		end
+		areas:save()
+
+		return true, "Total areas: " .. total .. ", Removed " ..
+			count .. " areas. New count: " .. (total - count)
+	end
+})

--- a/hud.lua
+++ b/hud.lua
@@ -4,7 +4,6 @@ areas.hud = {}
 areas.hud.refresh = 0
 
 minetest.register_globalstep(function(dtime)
-
 	areas.hud.refresh = areas.hud.refresh + dtime
 	if areas.hud.refresh > areas.config["tick"] then
 		areas.hud.refresh = 0
@@ -69,4 +68,3 @@ end)
 minetest.register_on_leaveplayer(function(player)
 	areas.hud[player:get_player_name()] = nil
 end)
-

--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,7 @@ minetest.register_privilege("areas", {
 	description = "Can administer areas."
 })
 minetest.register_privilege("areas_high_limit", {
-	description = "Can can more, bigger areas."
+	description = "Can protect more, bigger areas."
 })
 
 if not minetest.registered_privileges[areas.config.self_protection_privilege] then
@@ -38,4 +38,3 @@ if minetest.settings:get_bool("log_mods") then
 	local diffTime = os.clock() - areas.startTime
 	minetest.log("action", "areas loaded in "..diffTime.."s.")
 end
-

--- a/interact.lua
+++ b/interact.lua
@@ -17,4 +17,3 @@ minetest.register_on_protection_violation(function(pos, name)
 				table.concat(owners, ", ")))
 	end
 end)
-

--- a/internal.lua
+++ b/internal.lua
@@ -48,7 +48,7 @@ end
 function areas:checkAreaStoreId(sid)
 	if not sid then
 		minetest.log("error", "AreaStore failed to find an ID for an "
-			.."area!  Falling back to iterative area checking.")
+			.."area! Falling back to iterative area checking.")
 		self.store = nil
 		self.store_ids = nil
 	end
@@ -149,7 +149,6 @@ end
 function areas:move(id, area, pos1, pos2)
 	area.pos1 = pos1
 	area.pos2 = pos2
-
 
 	for i=1, #areas.registered_on_moves do
 		areas.registered_on_moves[i](id, area, pos1, pos2)

--- a/legacy.lua
+++ b/legacy.lua
@@ -137,4 +137,3 @@ if areas.config.legacy_table then
 		end
 	})
 end
-

--- a/locale/areas.fr.tr
+++ b/locale/areas.fr.tr
@@ -86,7 +86,7 @@ Area is too big.=La zone est trop grande.
 
 Self protection is disabled or you do not have the necessary privilege.=L’autoprotection est désactivée ou vous n’avez pas le privilège nécessaire.
 
-The area intersects with @1 [@2] (@3).=La zone a une intersection avec @1  [@2] (@3).
+The area intersects with @1 [@2] (@3).=La zone a une intersection avec @1 [@2] (@3).
 
 You have reached the maximum amount of areas that you are allowed to protect.=Vous avez atteint le nombre maximum de zones que vous êtes autorisé à protéger.
 

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -65,6 +65,8 @@ You have extended area protection limits ("areas_high_limit" privilege).=
 You have the necessary privilege ("@1").=
 You need to select an area first.=
 
+Removes all ownerless areas.=
+
 ### chatcommands.lua ###
 ### pos.lua ###
 

--- a/pos.lua
+++ b/pos.lua
@@ -1,4 +1,5 @@
 local S = minetest.get_translator("areas")
+
 -- I could depend on WorldEdit for this, but you need to have the 'worldedit'
 -- permission to use those commands and you don't have
 -- /area_pos{1,2} [X Y Z|X,Y,Z].
@@ -262,4 +263,3 @@ minetest.register_entity("areas:pos2", {
 		areas.marker2[name] = nil
 	end,
 })
-

--- a/settings.lua
+++ b/settings.lua
@@ -43,4 +43,3 @@ file:close()
 --------------
 
 setting("filename", "string", world_path.."/areas.dat")
-

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -35,4 +35,3 @@ areas.self_protection_max_size_high (Maximal area size) v3f (512, 512, 512)
 # Only enter positive whole numbers for the coordinate values or you'll mess up stuff.
 # This setting applies for plyaers with the privilege 'areas_high_limit'
 areas.self_protection_max_areas_high (Maximal area count) float 32
-


### PR DESCRIPTION
Not sure if anyone else needs this. I created my fork of this good mod some time ago.

During this time, more than 10,000 areas appeared on my server. I became worried that after removing a player, all of his areas are saved. Manually checking and clearing 10,000 records is not possible. So I add chatcommand for it.
If only I need this, I'm sorry.