### PR TITLE
Add require_protection and node_ownership_legacy settings

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -84,10 +84,15 @@ end
 
 -- Checks if the area is unprotected or owned by you
 function areas:canInteract(pos, name)
+	if name == "" then
+		return true -- Mods, namely minetest.item_place_node
+	end
 	if minetest.check_player_privs(name, self.adminPrivs) then
 		return true
 	end
-	local owned = false
+
+	-- Disallow interaction by default when the restrictive setting is enabled
+	local owned = areas.config.require_protection
 	for _, area in pairs(self:getAreasAtPos(pos)) do
 		if area.owner == name or area.open then
 			return true

--- a/init.lua
+++ b/init.lua
@@ -16,7 +16,9 @@ dofile(areas.modpath.."/internal.lua")
 dofile(areas.modpath.."/chatcommands.lua")
 dofile(areas.modpath.."/pos.lua")
 dofile(areas.modpath.."/interact.lua")
-dofile(areas.modpath.."/legacy.lua")
+if areas.config.node_ownership_legacy then
+	dofile(areas.modpath.."/legacy.lua")
+end
 dofile(areas.modpath.."/hud.lua")
 
 areas:load()

--- a/interact.lua
+++ b/interact.lua
@@ -9,11 +9,20 @@ function minetest.is_protected(pos, name)
 end
 
 minetest.register_on_protection_violation(function(pos, name)
-	if not areas:canInteract(pos, name) then
-		local owners = areas:getNodeOwners(pos)
-		minetest.chat_send_player(name,
-			S("@1 is protected by @2.",
-				minetest.pos_to_string(pos),
-				table.concat(owners, ", ")))
+	if areas:canInteract(pos, name) then
+		return
 	end
+
+	local owners = areas:getNodeOwners(pos)
+	if #owners == 0 then
+		-- When require_protection=true
+		minetest.chat_send_player(name,
+			S("@1 may not be accessed.",
+				minetest.pos_to_string(pos)))
+		return
+	end
+	minetest.chat_send_player(name,
+		S("@1 is protected by @2.",
+			minetest.pos_to_string(pos),
+			table.concat(owners, ", ")))
 end)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -8,30 +8,34 @@
 areas.self_protection (Self protection) bool false
 
 # Self protection: Privilege required to protect an area
-areas.self_protection_privilege (Self protection: Required privs) string interact
+areas.self_protection_privilege (Self protection: Required priv) string interact
 
-# Refresh delay for the name displays in the HUD in seconds
+# Limits interactions of players to the areas they have access to.
+# This setting is very restrictive and is not recommended for open-world games.
+areas.require_protection (Require protection) bool false
+
+# Area name HUD refresh delay in seconds
 areas.tick (HUD update delay) float 0.5 0 100
 
 # Enable the legacy owner_defs metatable mode. Untested and possibly unstable
-areas.legacy_table (Legacy owner_defs metatable) bool false
+areas.node_ownership_legacy (node_ownership compatibility) bool false
 
 [Self protection (normal)]
 
-# Self protection (normal): Maximal size of the protectable area
+# Maximal size of the protectable area
 # Only enter positive whole numbers for the coordinate values or you'll mess up stuff.
 areas.self_protection_max_size (Maximal area size) v3f (64, 128, 64)
 
-# Self protection (normal): Maximal amount of protected areas per player
+# Maximal amount of protected areas per player
 areas.self_protection_max_areas (Maximal area count) int 4
 
 [Self protection (high)]
 
-# Self protection (normal): Maximal size of the protectable area
-# This setting applies for plyaers with the privilege 'areas_high_limit'
+# For players with the 'areas_high_limit' privilege.
+# Maximal size of the protectable area
+# This setting applies for players with the privilege 'areas_high_limit'
 areas.self_protection_max_size_high (Maximal area size) v3f (512, 512, 512)
 
-# Self protection (normal): Maximal amount of protected areas per player
-# Only enter positive whole numbers for the coordinate values or you'll mess up stuff.
-# This setting applies for plyaers with the privilege 'areas_high_limit'
+# For players with the 'areas_high_limit' privilege.
+# Maximal amount of protected areas per player
 areas.self_protection_max_areas_high (Maximal area count) float 32


### PR DESCRIPTION
require_protection: Disallows interactions outside of owned areas
node_ownership_legacy: Skip 9+ year old compatibility code by default

`areas.config.legacy_table` was never used, hence removed/replaced.

Fixes #58
Fixes #54 

Feedback is welcome.