### PR TITLE
Add support for area_pos1 and area_pos2 chatcommands to accept coordinates separated by commas AND spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ Commands
   * `/area_pos {set,set1,set2,get}` -- Sets the area positions by punching
 	nodes or shows the current area positions.
 
-  * `/area_pos1 [X,Y,Z|X Y Z]` -- Sets area position one to your position or
+  * `/area_pos1 [X Y Z|X,Y,Z|X, Y, Z]` -- Sets area position one to your position or
 	the one supplied.
 
-  * `/area_pos2 [X,Y,Z|X Y Z]` -- Sets area position two to your position or
+  * `/area_pos2 [X Y Z|X,Y,Z|X, Y, Z]` -- Sets area position two to your position or
 	the one supplied.
 
   * `/areas_cleanup` -- Removes all ownerless areas.

--- a/pos.lua
+++ b/pos.lua
@@ -41,13 +41,13 @@ minetest.register_chatcommand("select_area", {
 })
 
 minetest.register_chatcommand("area_pos1", {
-	params = "[X Y Z|X,Y,Z]",
+	params = "[X Y Z|X,Y,Z|X, Y, Z]",
 	description = S("Set area protection region position @1 to your"
 		.." location or the one specified", "1"),
 	privs = {},
 	func = function(name, param)
 		local pos
-		local found, _, x, y, z = param:find(
+		local found, _, x, y, z = param:gsub(", ", ","):find(
 				"^(-?%d+)[, ](-?%d+)[, ](-?%d+)$")
 		if found then
 			pos = {x=tonumber(x), y=tonumber(y), z=tonumber(z)}
@@ -69,12 +69,12 @@ minetest.register_chatcommand("area_pos1", {
 })
 
 minetest.register_chatcommand("area_pos2", {
-	params = "[X Y Z|X,Y,Z]",
+	params = "[X Y Z|X,Y,Z|X, Y, Z]",
 	description = S("Set area protection region position @1 to your"
 		.." location or the one specified", "2"),
 	func = function(name, param)
 		local pos
-		local found, _, x, y, z = param:find(
+		local found, _, x, y, z = param:gsub(", ", ","):find(
 				"^(-?%d+)[, ](-?%d+)[, ](-?%d+)$")
 		if found then
 			pos = {x=tonumber(x), y=tonumber(y), z=tonumber(z)}


### PR DESCRIPTION
Add support for area_pos1 and area_pos2 chatcommands to accept coordinates separated by commas AND spaces rather than only commas OR spaces. Will also handle combinations of both such as caused by typos (e.g. `/area_pos 1, 2,3`) 