### PR TITLE
Allow relative coordinates in /area_pos[12]

### DIFF
--- a/locale/areas.fr.tr
+++ b/locale/areas.fr.tr
@@ -133,3 +133,5 @@ Set area protection region, position 1, or position 2 by punching nodes, or disp
 The area @1 does not exist.=La zone @1 n’existe pas.
 Unable to get position.=Impossible d’obtenir la position.
 Unknown subcommand: @1=Sous-commande inconnue : @1
+
+Relative coordinates is not supported on this server. Please upgrade Minetest to 5.7.0 or newer versions.=

--- a/locale/areas.it.tr
+++ b/locale/areas.it.tr
@@ -133,3 +133,5 @@ Set area protection region, position 1, or position 2 by punching nodes, or disp
 The area @1 does not exist.=L'area @1 non esiste.
 Unable to get position.=Impossibile ottenere la posizione.
 Unknown subcommand: @1=Sotto-comando sconosciuto: @1
+
+Relative coordinates is not supported on this server. Please upgrade Minetest to 5.7.0 or newer versions.=

--- a/locale/areas.ru.tr
+++ b/locale/areas.ru.tr
@@ -133,3 +133,5 @@ Set area protection region, position 1, or position 2 by punching nodes, or disp
 The area @1 does not exist.=Территория @1 не существует.
 Unable to get position.=Не удалось получить позицию.
 Unknown subcommand: @1=Неизвестная под-команда/аргумент.
+
+Relative coordinates is not supported on this server. Please upgrade Minetest to 5.7.0 or newer versions.=

--- a/locale/areas.zh_CN.tr
+++ b/locale/areas.zh_CN.tr
@@ -133,3 +133,5 @@ Set area protection region, position 1, or position 2 by punching nodes, or disp
 The area @1 does not exist.=保护区 @1 不存在。
 Unable to get position.=无法获得座标。
 Unknown subcommand: @1=子指令不明：@1
+
+Relative coordinates is not supported on this server. Please upgrade Minetest to 5.7.0 or newer versions.=此服务器不支援相对座标。请更新Minetest至5.7.0或之后的版本。

--- a/locale/areas.zh_TW.tr
+++ b/locale/areas.zh_TW.tr
@@ -133,3 +133,5 @@ Set area protection region, position 1, or position 2 by punching nodes, or disp
 The area @1 does not exist.=保護區 @1 不存在。
 Unable to get position.=無法獲得座標。
 Unknown subcommand: @1=子指令不明：@1
+
+Relative coordinates is not supported on this server. Please upgrade Minetest to 5.7.0 or newer versions.=此伺服器不支援相對座標。請更新Minetest至5.7.0或之後的版本。

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -133,3 +133,5 @@ Set area protection region, position 1, or position 2 by punching nodes, or disp
 The area @1 does not exist.=
 Unable to get position.=
 Unknown subcommand: @1=
+
+Relative coordinates is not supported on this server. Please upgrade Minetest to 5.7.0 or newer versions.=

--- a/pos.lua
+++ b/pos.lua
@@ -49,7 +49,7 @@ minetest.register_chatcommand("area_pos1", {
 		local pos
 		local player = minetest.get_player_by_name(name)
 		if player then
-			pos = player:get_pos()
+			pos = vector.round(player:get_pos())
 		end
 		local found, _, x_str, y_str, z_str = param:find(
 			"^(~?-?%d*)[, ](~?-?%d*)[, ](~?-?%d*)$")
@@ -84,7 +84,7 @@ minetest.register_chatcommand("area_pos2", {
 		local pos
 		local player = minetest.get_player_by_name(name)
 		if player then
-			pos = player:get_pos()
+			pos = vector.round(player:get_pos())
 		end
 		local found, _, x_str, y_str, z_str = param:find(
 			"^(~?-?%d*)[, ](~?-?%d*)[, ](~?-?%d*)$")

--- a/pos.lua
+++ b/pos.lua
@@ -47,19 +47,27 @@ minetest.register_chatcommand("area_pos1", {
 	privs = {},
 	func = function(name, param)
 		local pos
-		local found, _, x, y, z = param:find(
-				"^(-?%d+)[, ](-?%d+)[, ](-?%d+)$")
+		local player = minetest.get_player_by_name(name)
+		if player then
+			pos = player:get_pos()
+		end
+		local found, _, x_str, y_str, z_str = param:find(
+			"^(~?-?%d*)[, ](~?-?%d*)[, ](~?-?%d*)$")
 		if found then
-			pos = {x=tonumber(x), y=tonumber(y), z=tonumber(z)}
-		elseif param == "" then
-			local player = minetest.get_player_by_name(name)
-			if player then
-				pos = player:get_pos()
-			else
-				return false, S("Unable to get position.")
+			local x = pos and minetest.parse_relative_number(x_str, pos.x)
+				or tonumber(x_str)
+			local y = pos and minetest.parse_relative_number(y_str, pos.y)
+				or tonumber(y_str)
+			local z = pos and minetest.parse_relative_number(z_str, pos.z)
+				or tonumber(z_str)
+			if x and y and z then
+				pos = { x = x, y = y, z = z }
 			end
-		else
+		elseif param ~= "" then
 			return false, S("Invalid usage, see /help @1.", "area_pos1")
+		end
+		if not pos then
+			return false, S("Unable to get position.")
 		end
 		pos = posLimit(vector.round(pos))
 		areas:setPos1(name, pos)
@@ -74,19 +82,27 @@ minetest.register_chatcommand("area_pos2", {
 		.." location or the one specified", "2"),
 	func = function(name, param)
 		local pos
-		local found, _, x, y, z = param:find(
-				"^(-?%d+)[, ](-?%d+)[, ](-?%d+)$")
+		local player = minetest.get_player_by_name(name)
+		if player then
+			pos = player:get_pos()
+		end
+		local found, _, x_str, y_str, z_str = param:find(
+			"^(~?-?%d*)[, ](~?-?%d*)[, ](~?-?%d*)$")
 		if found then
-			pos = {x=tonumber(x), y=tonumber(y), z=tonumber(z)}
-		elseif param == "" then
-			local player = minetest.get_player_by_name(name)
-			if player then
-				pos = player:get_pos()
-			else
-				return false, S("Unable to get position.")
+			local x = pos and minetest.parse_relative_number(x_str, pos.x)
+				or tonumber(x_str)
+			local y = pos and minetest.parse_relative_number(y_str, pos.y)
+				or tonumber(y_str)
+			local z = pos and minetest.parse_relative_number(z_str, pos.z)
+				or tonumber(z_str)
+			if x and y and z then
+				pos = { x = x, y = y, z = z }
 			end
-		else
+		elseif param ~= "" then
 			return false, S("Invalid usage, see /help @1.", "area_pos2")
+		end
+		if not pos then
+			return false, S("Unable to get position.")
 		end
 		pos = posLimit(vector.round(pos))
 		areas:setPos2(name, pos)


### PR DESCRIPTION
This PR allows coordinates relative to player position to be passed into `/area_pos[12]`.

There is a minor regression: Typing in `/area_pos1 - - -` would result in the player coordinates being set instead of raising an error as it would.

This PR is ready for review.