### PR TITLE
Replace deprecated hud_elem_type field in main HUD

### DIFF
--- a/hud.lua
+++ b/hud.lua
@@ -66,6 +66,7 @@ minetest.register_globalstep(function(dtime)
 			hud = {}
 			areas.hud[name] = hud
 			hud.areasId = player:hud_add({
+				hud_elem_type = "text", -- ignored on new clients
 				type = "text",
 				name = "Areas",
 				number = 0xFFFFFF,

--- a/hud.lua
+++ b/hud.lua
@@ -66,7 +66,7 @@ minetest.register_globalstep(function(dtime)
 			hud = {}
 			areas.hud[name] = hud
 			hud.areasId = player:hud_add({
-				[minetest.features.hud_def_type_field and "type" or "hud_elem_type"] = "text", -- compatible with older version 
+				[minetest.features.hud_def_type_field and "type" or "hud_elem_type"] = "text", -- compatible with older versions
 				name = "Areas",
 				number = 0xFFFFFF,
 				position = {x=0, y=1},

--- a/hud.lua
+++ b/hud.lua
@@ -66,8 +66,7 @@ minetest.register_globalstep(function(dtime)
 			hud = {}
 			areas.hud[name] = hud
 			hud.areasId = player:hud_add({
-				hud_elem_type = "text", -- ignored on new clients
-				type = "text",
+				[minetest.features.hud_def_type_field and "type" or "hud_elem_type"] = "text", -- compatible with older version 
 				name = "Areas",
 				number = 0xFFFFFF,
 				position = {x=0, y=1},

--- a/hud.lua
+++ b/hud.lua
@@ -66,7 +66,7 @@ minetest.register_globalstep(function(dtime)
 			hud = {}
 			areas.hud[name] = hud
 			hud.areasId = player:hud_add({
-				hud_elem_type = "text",
+				type = "text",
 				name = "Areas",
 				number = 0xFFFFFF,
 				position = {x=0, y=1},


### PR DESCRIPTION
This PR replaces `hud_elem_type` in the HUD definition with `type`. This PR is ready for review.