### PR TITLE
Use smallest area at given position

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -95,20 +95,21 @@ function areas:getAreasIntersectingArea(pos1, pos2)
 	return res
 end
 
--- Returns smallest area at position or nil.
+-- Returns smallest area at position and its id or nil.
 -- If multiple areas have the same volume, larger id takes precedence.
 function areas:getSmallestAreaAtPos(pos)
-	local smallest_area, smallest_volume, volume = nil
-	for _, area in pairs(self:getAreasAtPos(pos)) do
+	local smallest_area, smallest_id, smallest_volume, volume = nil
+	for id, area in pairs(self:getAreasAtPos(pos)) do
 		volume =	(area.pos2.x - area.pos1.x + 1)
 					* (area.pos2.y - area.pos1.y + 1)
 					* (area.pos2.z - area.pos1.z + 1)
 		if not smallest_volume or smallest_volume >= volume then
 			smallest_area = area
+			smallest_id = id
 			smallest_volume = volume
 		end
 	end
-	return smallest_area
+	return smallest_area, smallest_id
 end
 
 -- Checks if the area is unprotected, open, owned by player

--- a/api.lua
+++ b/api.lua
@@ -98,12 +98,13 @@ end
 -- Returns smallest area at position and its id or nil.
 -- If multiple areas have the same volume, larger id takes precedence.
 function areas:getSmallestAreaAtPos(pos)
-	local smallest_area, smallest_id, smallest_volume, volume = nil
+	local smallest_area, smallest_id, volume
+	local smallest_volume = math.huge
 	for id, area in pairs(self:getAreasAtPos(pos)) do
 		volume =	(area.pos2.x - area.pos1.x + 1)
 					* (area.pos2.y - area.pos1.y + 1)
 					* (area.pos2.z - area.pos1.z + 1)
-		if not smallest_volume or smallest_volume >= volume then
+		if smallest_volume >= volume then
 			smallest_area = area
 			smallest_id = id
 			smallest_volume = volume


### PR DESCRIPTION
When checking for permission to interact, currently the smallest id takes precedence in a situation where areas enclose other areas. This makes it complicated to set up private areas within faction areas and vice versa. Same applies for open areas within a bigger private area.

When multiple areas have the same volume, players seem to agree that the most recently protected area should also take precedence.
Since we can't guarantee that the largest id is the most recent, we still use that info as we have no other way to determine age.

In this PR the smallest area is determined and protection checks applied to that one.

Example usage: https://github.com/mt-mods/xp_redo/pull/74