### PR TITLE
Make smallest area concept optional

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -95,20 +95,21 @@ function areas:getAreasIntersectingArea(pos1, pos2)
 	return res
 end
 
--- Returns smallest area at position or nil.
+-- Returns smallest area at position and its id or nil.
 -- If multiple areas have the same volume, larger id takes precedence.
 function areas:getSmallestAreaAtPos(pos)
-	local smallest_area, smallest_volume, volume = nil
-	for _, area in pairs(self:getAreasAtPos(pos)) do
+	local smallest_area, smallest_id, smallest_volume, volume = nil
+	for id, area in pairs(self:getAreasAtPos(pos)) do
 		volume =	(area.pos2.x - area.pos1.x + 1)
 					* (area.pos2.y - area.pos1.y + 1)
 					* (area.pos2.z - area.pos1.z + 1)
 		if not smallest_volume or smallest_volume >= volume then
 			smallest_area = area
+			smallest_id = id
 			smallest_volume = volume
 		end
 	end
-	return smallest_area
+	return smallest_area, smallest_id
 end
 
 -- Checks if the area is unprotected, open, owned by player

--- a/api.lua
+++ b/api.lua
@@ -121,11 +121,7 @@ function areas:canInteract(pos, name)
 	end
 	local areas_list
 	if areas.config.use_smallest_area_precedence then
-		local smallest_area = self:getSmallestAreaAtPos(pos)
-		-- No area
-		if not smallest_area then
-			return true
-		end
+		local smallest_area, _ = self:getSmallestAreaAtPos(pos)
 		areas_list = { smallest_area }
 	else
 		areas_list = self:getAreasAtPos(pos)

--- a/api.lua
+++ b/api.lua
@@ -98,12 +98,13 @@ end
 -- Returns smallest area at position and its id or nil.
 -- If multiple areas have the same volume, larger id takes precedence.
 function areas:getSmallestAreaAtPos(pos)
-	local smallest_area, smallest_id, smallest_volume, volume = nil
+	local smallest_area, smallest_id, volume
+	local smallest_volume = math.huge
 	for id, area in pairs(self:getAreasAtPos(pos)) do
 		volume =	(area.pos2.x - area.pos1.x + 1)
 					* (area.pos2.y - area.pos1.y + 1)
 					* (area.pos2.z - area.pos1.z + 1)
-		if not smallest_volume or smallest_volume >= volume then
+		if smallest_volume >= volume then
 			smallest_area = area
 			smallest_id = id
 			smallest_volume = volume

--- a/api.lua
+++ b/api.lua
@@ -101,9 +101,9 @@ function areas:getSmallestAreaAtPos(pos)
 	local smallest_area, smallest_id, volume
 	local smallest_volume = math.huge
 	for id, area in pairs(self:getAreasAtPos(pos)) do
-		volume =	(area.pos2.x - area.pos1.x + 1)
-					* (area.pos2.y - area.pos1.y + 1)
-					* (area.pos2.z - area.pos1.z + 1)
+		volume = (area.pos2.x - area.pos1.x + 1)
+				* (area.pos2.y - area.pos1.y + 1)
+				* (area.pos2.z - area.pos1.z + 1)
 		if smallest_volume >= volume then
 			smallest_area = area
 			smallest_id = id

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -4,6 +4,14 @@
 #areas.filename (Configuration file path) string (world_path)/areas.dat
 
 # Use smallest area volume precedence concept. (experimental may change)
+# Determine area access based on the smallest area volume that contains
+# the interaction position. Sharing areas is achieved with factions instead
+# of using /add_owner.
+# This allows players to have private areas within a greater open/shared area
+# and also define open/shared areas within those private areas.
+# If set to `false`: interacting is allowed if the interaction position
+# resides in the players own area, area is open or shared with factions.
+# Even if other more restrictive areas enclose the interaction position.
 areas.use_smallest_area_precedence (Smallest area rules) bool false
 
 # Allow players with a privilege create their own areas using /protect

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -3,6 +3,9 @@
 # Static paths do not work well with settings
 #areas.filename (Configuration file path) string (world_path)/areas.dat
 
+# Use smallest area volume precedence concept. (experimental may change)
+areas.use_smallest_area_precedence (Smallest area rules) bool false
+
 # Allow players with a privilege create their own areas using /protect
 # within the specified size and amount limits.
 areas.self_protection (Self protection) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -3,15 +3,18 @@
 # Static paths do not work well with settings
 #areas.filename (Configuration file path) string (world_path)/areas.dat
 
-# Use smallest area volume precedence concept. (experimental may change)
-# Determine area access based on the smallest area volume that contains
-# the interaction position. Sharing areas is achieved with factions instead
-# of using /add_owner.
-# This allows players to have private areas within a greater open/shared area
-# and also define open/shared areas within those private areas.
-# If set to `false`: interacting is allowed if the interaction position
-# resides in the players own area, area is open or shared with factions.
-# Even if other more restrictive areas enclose the interaction position.
+# Use smallest area volume precedence concept. (experimental; may change)
+#
+# If set to `true`:
+#    The interaction permission is defined by the smallest area volume that
+#    contains the interaction position. Granting access to areas is achieved
+#    by factions instead of using `/add_owner`.
+#    This allows players to have private areas within a greater open/shared
+#    area and also define open/shared areas within those private areas.
+# If set to `false`: (default)
+#    Interacting is permitted if the interaction position resides in any of the
+#    player's own areas, shared or open areas.
+#    This permission is not impacted by more restrictive, intersecting areas.
 areas.use_smallest_area_precedence (Smallest area rules) bool false
 
 # Allow players with a privilege create their own areas using /protect


### PR DESCRIPTION
- Reverts default behaviour to before #79
- Allows experimental enthusiasts to use #79 by togglig a setting
see comments in #79

The diff may make it look like much changed, but I only wrapped current and previous behaviour into an if then else clause and added the setting in settingtypes.txt.