### PR TITLE
Allow admins to list all areas if they want to

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -180,7 +180,11 @@ minetest.register_chatcommand("list_areas", {
 		local admin_show_summary = admin
 		local owner_name = name
 
-		if admin and #param > 0 then
+		param = param:trim()
+
+		if param == "*" then
+			admin_show_summary = false
+		elseif admin and #param > 0 then
 			owner_name = param
 			admin_show_summary = false
 		end


### PR DESCRIPTION
Allows admins to get all areas (instead of the summary introduced in #72) by executing `/list_areas *`.

This PR is ready for review.