### PR TITLE
Embed co-owner data into the area itself

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -128,8 +128,10 @@ function areas:canInteract(pos, name)
 	end
 	local owned = false
 	for _, area in pairs(areas_list) do
-		-- Player owns the area or area is open
-		if area.owner == name or area.open then
+		-- Player owns the area, area is open, or player is a co-owner
+		if area.owner == name
+			or area.open
+			or (area.co_owners and area.co_owners[name]) then
 			return true
 		elseif areas.factions_available and area.faction_open then
 			if (factions.version or 0) < 2 then

--- a/hud.lua
+++ b/hud.lua
@@ -42,10 +42,16 @@ minetest.register_globalstep(function(dtime)
 				end
 			end
 
-			table.insert(areaStrings, ("%s [%u] (%s%s%s)")
+			local coOwnersCount = 0
+			for _ in pairs(areas:listCoOwners(id)) do
+				coOwnersCount = coOwnersCount + 1
+			end
+
+			table.insert(areaStrings, ("%s [%u] (%s%s%s)%s")
 					:format(area.name, id, area.owner,
 					area.open and S(":open") or "",
-					faction_info and ": "..faction_info or ""))
+					faction_info and ": "..faction_info or "",
+					coOwnersCount ~= 0 and " +" .. coOwnersCount or ""))
 		end
 
 		for i, area in pairs(areas:getExternalHudEntries(pos)) do

--- a/internal.lua
+++ b/internal.lua
@@ -217,6 +217,30 @@ function areas:getChildren(id)
 	return children
 end
 
+-- Add a co-owner to an area
+function areas:addCoOwner(id, name)
+	local entry = self.areas[id]
+	entry.co_owners = entry.co_owners or {}
+	entry.co_owners[name] = true
+end
+
+-- Remove a co-owner from an area
+function areas:removeCoOwner(id, name)
+	local entry = self.areas[id]
+	if entry.co_owners then
+		entry.co_owners[name] = nil
+		if next(entry.co_owners) == nil then
+			entry.co_owners = nil
+		end
+	end
+end
+
+-- Return the list of co-owners
+function areas:listCoOwners(id)
+	local entry = self.areas[id]
+	return entry.co_owners and table.copy(entry.co_owners) or {}
+end
+
 -- checks all possible restrictions registered with
 -- areas:registerProtectionCondition
 -- builtin callbacks below


### PR DESCRIPTION
This PR adds a `co_owners` field to area entries to store additional owners. These co-owners would be granted normal access rights but no rights to manage that area. This approach solved the mess with `/add_owner`, where a very long list of users would appear if that area is shared among many players.

This PR is ready for review.